### PR TITLE
Finish rest of API

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,8 @@ author = 'Trishank Karthik Kuppusamy'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
-    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.githubpages',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/hvac_openpgp/api.py
+++ b/hvac_openpgp/api.py
@@ -164,7 +164,36 @@ class OpenPGP(Transit):
         )
 
     def delete_key(self, name, mount_point=DEFAULT_MOUNT_POINT):
-        raise NotImplementedError
+        """Delete a named encryption key.
+
+        It will no longer be possible to decrypt any data encrypted with the named key. Because this is a potentially
+        catastrophic operation, the deletion_allowed tunable must be set in the key's /config endpoint.
+        Not supported at the time of writing; use Vault policies instead to control who can delete which keys.
+
+        Supported methods:
+            DELETE: /{mount_point}/keys/{name}. Produces: 204 (empty body)
+
+        :param name: Specifies the name of the encryption key to delete. This is specified as part of the URL.
+        :type name: str | unicode
+
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+
+        # JSON parameters to the plugin.
+        api_path = format_url(
+            '/v1/{mount_point}/keys/{name}',
+            mount_point=mount_point,
+            name=name,
+        )
+
+        # The actual call to the plugin.
+        return self._adapter.delete(
+            url=api_path,
+        )
 
     def update_key_configuration(self, name, min_decryption_version=None, min_encryption_version=None, deletion_allowed=None,
                                  exportable=None, allow_plaintext_backup=None, mount_point=DEFAULT_MOUNT_POINT):

--- a/hvac_openpgp/api.py
+++ b/hvac_openpgp/api.py
@@ -285,8 +285,8 @@ class OpenPGP(Transit):
     def generate_hmac(self, name, hash_input, key_version=None, algorithm=None, mount_point=DEFAULT_MOUNT_POINT):
         raise NotImplementedError
 
-    def sign_data(self, name, hash_input, key_version=None, hash_algorithm=None, context=None, prehashed=None,
-                  signature_algorithm=None, marshaling_algorithm=None, mount_point=DEFAULT_MOUNT_POINT):
+    def sign_data(self, name, hash_input, key_version=None, hash_algorithm='sha2-512', context=None, prehashed=None,
+                  signature_algorithm=None, marshaling_algorithm='ascii-armor', mount_point=DEFAULT_MOUNT_POINT):
         """Return the cryptographic signature of the given data using the named key and the specified hash algorithm.
 
         The key must be of a type that supports signing.
@@ -390,7 +390,8 @@ class OpenPGP(Transit):
         )
 
     def verify_signed_data(self, name, hash_input, signature=None, hmac=None, hash_algorithm=None, context=None,
-                           prehashed=None, signature_algorithm=None, marshaling_algorithm=None, mount_point=DEFAULT_MOUNT_POINT):
+                           prehashed=None, signature_algorithm=None, marshaling_algorithm='ascii-armor',
+                           mount_point=DEFAULT_MOUNT_POINT):
         """Return whether the provided signature is valid for the given data.
 
         Supported methods:

--- a/hvac_openpgp/api.py
+++ b/hvac_openpgp/api.py
@@ -142,7 +142,26 @@ class OpenPGP(Transit):
         )
 
     def list_keys(self, mount_point=DEFAULT_MOUNT_POINT):
-        raise NotImplementedError
+        """List keys (if there are any).
+
+        Only the key names are returned (not the actual keys themselves).
+        An exception is thrown if there are no keys.
+
+        Supported methods:
+            LIST: /{mount_point}/keys. Produces: 200 application/json
+
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+
+        # The actual call to the plugin.
+        api_path = format_url('/v1/{mount_point}/keys', mount_point=mount_point)
+        return self._adapter.list(
+            url=api_path
+        )
 
     def delete_key(self, name, mount_point=DEFAULT_MOUNT_POINT):
         raise NotImplementedError

--- a/hvac_openpgp/constants.py
+++ b/hvac_openpgp/constants.py
@@ -3,6 +3,12 @@
 """Constants related to the Transit-Secrets-like-Engine."""
 
 from hvac.constants.transit import ALLOWED_HASH_DATA_ALGORITHMS
+
+ALLOWED_EXPORT_KEY_TYPES = {
+    'encryption-key',
+    'signing-key',
+}
+
 ALLOWED_HASH_DATA_ALGORITHMS = set(ALLOWED_HASH_DATA_ALGORITHMS)
 
 ALLOWED_KEY_TYPES = {

--- a/hvac_openpgp/constants.py
+++ b/hvac_openpgp/constants.py
@@ -2,8 +2,19 @@
 # -*- coding: utf-8 -*-
 """Constants related to the Transit-Secrets-like-Engine."""
 
-ALLOWED_KEY_TYPES = [
+from hvac.constants.transit import ALLOWED_HASH_DATA_ALGORITHMS
+
+ALLOWED_KEY_TYPES = {
     'rsa-2048',
     'rsa-3072',
     'rsa-4096',
-]
+}
+
+ALLOWED_MARSHALING_ALGORITHMS = {
+    'ascii-armor',
+    'base64',
+}
+
+ALLOWED_SIGNATURE_ALGORITHMS = {
+        'pkcs1v15',
+}

--- a/hvac_openpgp/constants.py
+++ b/hvac_openpgp/constants.py
@@ -3,6 +3,7 @@
 """Constants related to the Transit-Secrets-like-Engine."""
 
 from hvac.constants.transit import ALLOWED_HASH_DATA_ALGORITHMS
+ALLOWED_HASH_DATA_ALGORITHMS = set(ALLOWED_HASH_DATA_ALGORITHMS)
 
 ALLOWED_KEY_TYPES = {
     'rsa-2048',

--- a/tests/test_transit_api.py
+++ b/tests/test_transit_api.py
@@ -177,7 +177,7 @@ class TestOpenPGP(unittest.TestCase):
       with self.assertRaises(InvalidRequest, msg='Not base64 hash input!'):
         self.openpgp.verify_signed_data(fixed_name, fixed_input, signature='')
 
-      # All supported as well as default hash, marshaling, and signature algorithms.
+      # All supported as well as empty hash, marshaling, and signature algorithms.
       for hash_algorithm in ALLOWED_HASH_DATA_ALGORITHMS | {None}:
         for marshaling_algorithm in ALLOWED_MARSHALING_ALGORITHMS | {None}:
           for signature_algorithm in ALLOWED_SIGNATURE_ALGORITHMS | {None}:
@@ -220,6 +220,14 @@ class TestOpenPGP(unittest.TestCase):
                                                 signature=bad_signature,
                                                 signature_algorithm=signature_algorithm)
             self.assertFalse(r['data']['valid'])
+
+            # TODO: pass in mismatching hashing/marshaling algorithm.
+
+      # Test default hashing/marshaling algorithms.
+      r = self.openpgp.sign_data(fixed_name, base64_input)
+      signature = r['data']['signature']
+      r = self.openpgp.verify_signed_data(fixed_name, base64_input, signature=signature)
+      self.assertTrue(r['data']['valid'])
 
   def test_5_delete_key(self):
       # Deleting a nonexistent key does not raise an exception.

--- a/tests/test_transit_api.py
+++ b/tests/test_transit_api.py
@@ -37,7 +37,27 @@ class TestOpenPGP(unittest.TestCase):
   def random_name(self):
     return str(uuid.uuid4())
 
-  def test_create_and_read_key(self):
+  def test_1_list_keys(self):
+    # List keys when there are none.
+    with self.assertRaises(InvalidPath, msg='Listed keys when there are none!'):
+      self.openpgp.list_keys()
+
+    # Create and list keys.
+    keys = []
+    for key_type in ALLOWED_KEY_TYPES:
+      name = self.random_name()
+      self.openpgp.create_key(name, key_type=key_type)
+      keys.append(name)
+
+    r = self.openpgp.list_keys()
+    assert sorted(r['data']['keys']) == sorted(keys)
+
+  def test_2_read_key(self):
+      # Read non-existent key.
+      with self.assertRaises(InvalidPath, msg='Read non-existent key!'):
+        self.openpgp.read_key(self.random_name())
+
+  def test_3_create_and_read_key(self):
     # Unsupported parameters.
     unsupported_parameters = (
       {'allow_plaintext_backup': True},
@@ -85,11 +105,6 @@ class TestOpenPGP(unittest.TestCase):
             self.assertNotIn('name', data)
             self.assertNotIn('key', data)
 
-  def test_read_key(self):
-    # Read non-existent key.
-    with self.assertRaises(InvalidPath, msg='Read non-existent key!'):
-      self.openpgp.read_key(self.random_name())
-
   # https://hvac.readthedocs.io/en/stable/usage/secrets_engines/transit.html#sign-data
   def base64ify(self, bytes_or_str):
       """Helper method to perform base64 encoding across Python 2.7 and Python 3.X"""
@@ -105,7 +120,7 @@ class TestOpenPGP(unittest.TestCase):
       else:
           return output_bytes
 
-  def test_sign_and_verify_data(self):
+  def test_4_sign_and_verify_data(self):
     for key_type in ALLOWED_KEY_TYPES:
       fixed_name = self.random_name()
       fixed_input = 'Hello, world!'


### PR DESCRIPTION
TODO:
- [x] Sign Data
- [x] Verify Signed Data
- [x] List Keys
- [x] Delete Key
- [x] Export Key
- [x] Default to RSA-4096 for Create Key
- [x] Default to SHA2-512 for Sign Data
- [x] Default to ascii-armor for Sign and Verify Signed Data
- Update tests to test defaults

Signed-off-by: Trishank Karthik Kuppusamy <trishank.kuppusamy@datadoghq.com>